### PR TITLE
Defer loading default slot with scopedSlots

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,16 +8,17 @@ export default {
       default: 'div'
     }
   },
-  render(h, { parent, slots, props }) {
-    const { default: defaultSlot = [], placeholder: placeholderSlot } = slots()
+  render(h, { parent, scopedSlots, props }) {
 
     if (parent._isMounted) {
-      return defaultSlot
+      return scopedSlots.default(undefined);
     }
 
     parent.$once('hook:mounted', () => {
       parent.$forceUpdate()
     })
+
+    const placeholderSlot = scopedSlots.placeholder(undefined) || [];
 
     if (props.placeholderTag && (props.placeholder || placeholderSlot)) {
       return h(
@@ -28,6 +29,8 @@ export default {
         props.placeholder || placeholderSlot
       )
     }
+
+    const defaultSlot = scopedSlots.default(undefined) || [];
 
     // Return a placeholder element for each child in the default slot
     // Or if no children return a single placeholder

--- a/src/index.js
+++ b/src/index.js
@@ -9,16 +9,15 @@ export default {
     }
   },
   render(h, { parent, scopedSlots, props }) {
-
     if (parent._isMounted) {
-      return scopedSlots.default(undefined);
+      return scopedSlots.default(undefined)
     }
 
     parent.$once('hook:mounted', () => {
       parent.$forceUpdate()
     })
 
-    const placeholderSlot = scopedSlots.placeholder(undefined) || [];
+    const placeholderSlot = scopedSlots.placeholder(undefined) || []
 
     if (props.placeholderTag && (props.placeholder || placeholderSlot)) {
       return h(
@@ -30,7 +29,7 @@ export default {
       )
     }
 
-    const defaultSlot = scopedSlots.default(undefined) || [];
+    const defaultSlot = scopedSlots.default(undefined) || []
 
     // Return a placeholder element for each child in the default slot
     // Or if no children return a single placeholder


### PR DESCRIPTION
There is a problem when using this in SSR mode. Take this issue as example: https://github.com/egoist/vue-client-only/issues/41

Or this question on SO: https://stackoverflow.com/questions/59347414/why-is-my-client-only-component-in-nuxt-complaining-that-window-is-not-define

The problem has its root in the fact, that executing `slots()` function executes the whole Virtual DOM for the default slot, even if it won't be used afterwards, like in SSR mode.
If you try to use some client-side component inside, even with lazy loading, it will fail, because virtual dom for this component will be executed even on server side.

Cleanest solution is to used `scopedSlots`, which are lazy loaded, you can run the slot virtual dom function only if you are sure, that it's a client side. Using this is trivial to make client-only, asynchronously loaded components without hacks.

This allows to use `client-only` also with components that are not well prepared for SSR.