### PR TITLE
add alternate detection methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,12 @@ export default {
   render(h, { parent, slots, props }) {
     const { default: defaultSlot = [], placeholder: placeholderSlot } = slots()
 
-    if (parent._isMounted) {
+    const isServerRendered =
+      !parent._isMounted || // default detection
+      !!window.__PRERENDER_STATUS || // prerender-spa-plugin
+      navigator.userAgent === 'ReactSnap' // react-snap
+
+    if (!isServerRendered) {
       return defaultSlot
     }
 


### PR DESCRIPTION
I have created this PR to allow this component to function with multiple prerendering libraries. The ones I have tested so far are below:

| Library 	| Working 	| Notes 	|
|-	|-	|-	|
| `react-snap` 	| ✔️ 	| [details](https://github.com/stereobooster/react-snap/issues/487#issuecomment-675298364) 	|
| `prerender-spa-plugin`  	| not tested yet 	| [details](https://github.com/chrisvfritz/prerender-spa-plugin/issues/317#issuecomment-554682599) 	|
| `presite` 	| not implemented yet 	| awaiting response from library author 	|
| `snapshotify` 	| not implemented yet 	| awaiting response from library author 	|
| `prerenderer` 	| not implemented yet 	| awaiting response from library author 	|
| `prep` 	| not implemented yet 	| awaiting response from library author 	|

I will update this PR as I hear back from the library authors. I will also happily add detection methods for other libraries as requested if I can find out how to detect that the app is being prerendered.