### PR TITLE
Support customize placeholder class

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ eg, show a loading indicator.
 </script>
 ```
 
-By default the placeholder will be wrapped in a `div` tag, however you can use `placeholderTag` prop to customize it:
+By default the placeholder will be wrapped in a `div` tag with `client-only-placeholder` class, however you can use `placeholderTag` and `placeholderClass` prop to customize it:
 
 ```vue
-<client-only placeholder="loading" placeholder-tag="span">
+<client-only placeholder="loading" placeholder-tag="span" placeholder-class="my-placeholder-class">
   <comments />
 </client-only>
 ```
@@ -78,7 +78,7 @@ By default the placeholder will be wrapped in a `div` tag, however you can use `
 And you get:
 
 ```html
-<span class="client-only-placeholder">
+<span class="my-placeholder-class">
   loading
 </span>
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,10 @@ export default {
     placeholderTag: {
       type: String,
       default: 'div'
+    },
+    placeholderClass: {
+      type: String,
+      default: 'client-only-placeholder'
     }
   },
   render(h, { parent, slots, props }) {
@@ -23,7 +27,7 @@ export default {
       return h(
         props.placeholderTag,
         {
-          class: ['client-only-placeholder']
+          class: [props.placeholderClass]
         },
         props.placeholder || placeholderSlot
       )

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,7 @@ import { FunctionalComponentOptions } from 'vue';
 export interface ClientOnlyProps {
   placeholder?: string;
   placeholderTag?: string;
+  placeholderClass?: string;
 }
 
 declare const ClientOnly: FunctionalComponentOptions<ClientOnlyProps>;


### PR DESCRIPTION
With this PR, we can customize placeholder class:

```html
<client-only placeholder="loading" placeholder-class="my-placeholder-class">
  <comments />
</client-only>
```

And we will get:

```html
<div class="my-placeholder-class">
  loading
</div>
```